### PR TITLE
Fix Node.js engine version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "webpack-cli": "^3.3.10"
   },
   "engines": {
-    "node": "10",
+    "node": ">=10",
     "npm": ">=6"
   },
   "homepage": "https://github.com/jet2jet/js-synthesizer",


### PR DESCRIPTION
Fixes #4.

The required Node.js version should not be 10, but >=10.